### PR TITLE
Feature/iat 385

### DIFF
--- a/application.yml
+++ b/application.yml
@@ -34,4 +34,4 @@ zuul:
 
 server:
   session:
-    timeout: 30
+    timeout: 240

--- a/application.yml
+++ b/application.yml
@@ -32,3 +32,6 @@ zuul:
       path: /api/ims/**
       url: http://localhost:8081/api
 
+server:
+  session:
+    timeout: 30

--- a/src/main/java/org/opentestsystem/ap/iat/config/RedisSessionConfig.java
+++ b/src/main/java/org/opentestsystem/ap/iat/config/RedisSessionConfig.java
@@ -13,16 +13,32 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.opentestsystem.ap.iat.config;
 
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.session.data.redis.RedisOperationsSessionRepository;
 import org.springframework.session.data.redis.config.annotation.web.http.EnableRedisHttpSession;
+
+import javax.annotation.PostConstruct;
 
 @Configuration
 @ConditionalOnProperty(value = "spring.session.enabled", havingValue = "true", matchIfMissing = true)
 @EnableRedisHttpSession
 public class RedisSessionConfig {
+
+  // default 15 minutes
+  @Value("${server.session.timeout:900}")
+  private Integer maxInactiveIntervalInMinutes;
+
+  @Autowired
+  private RedisOperationsSessionRepository sessionRepository;
+
+  @PostConstruct
+  private void afterPropertiesSet() {
+    sessionRepository.setDefaultMaxInactiveInterval(maxInactiveIntervalInMinutes);
+  }
 
 }


### PR DESCRIPTION
The local session timeout is configurable in IAT.  If nothing is configured the default timeout is 900 seconds (or 15 minutes) .  The project root application.yml is configured with 240 seconds (or 4 minutes) so when developing locally the timeout is 4 minutes.

Yet to confirm but the global session timeout managed by OpenAM is 5 to 10 minutes, at least from what we have noticed developing locally.  We want to put the local session less than the global session so the local session when expired will trigger IAT to authenticate with OpenAM.  This gives the IAT user a new session without requiring them to login and it resets the expiration on the global session.

Initially this wasn't working as expected.  I assumed setting the server.session.timeout would work but it didn't.  The Redis session continued to default to 30 minutes.  This lead to what you see in RedisSessionConfig.

This was tested by configuring the session timeout to 1 minute.  Then triggering the app to make a server side call.  I did this in the browser directly calling IMS  from IAT http://localhost:8080/api/ims/v1/ping.  The browser would redirect to OpenAM and back to IAT where a new session was established.  On a side note, it looks like it redirects back to page the user was one.  There is still an error thrown when the session times out the angular app makes a call to IMS.  Not sure yet what is happening there. 

Testing showed if the session timeout is set to 30 seconds it is really 1 minute when the application runs.  So it seems the the minimum the timeout can be is 1 minute.  Also it looks like increments of minutes are all that is supported so configuring 90 seconds will be 2 minutes at runtime.