### PR TITLE
Changed private variables to public; Prod build was not completing

### DIFF
--- a/src/app/item-create/item-create.component.ts
+++ b/src/app/item-create/item-create.component.ts
@@ -17,10 +17,9 @@ import { Item } from '../service/item';
 
 export class ItemCreateComponent implements OnInit {
 
-  private currentItem = new Item();
-  private errorMessage: string;
-
-  private navBarMessage: string;
+  public currentItem = new Item();
+  public errorMessage: string;
+  public navBarMessage: string;
 
   constructor(
     private route: ActivatedRoute,


### PR DESCRIPTION
The changes look good and we will merge them.

Should we put the copyright at the top of all typescript files (.ts)?

When defining class properties as public should we use the 'public' keyword or no keyword as public is the default?  I like the idea of not putting public as it is less to write, read, maintain, etc.

We discussed accessors (see https://www.typescriptlang.org/docs/handbook/classes.html) which seems like a good approach.  It mirrors the properties concept in .NET and  some of the Java Bean concept in Java.  Plus IntelliJ can create the 'get' and 'set' methods for us.
