### PR TITLE
IAT-416: Updated HomeController to have mappings for all routes in th…

### DIFF
--- a/src/main/java/org/opentestsystem/ap/iat/controller/HomeController.java
+++ b/src/main/java/org/opentestsystem/ap/iat/controller/HomeController.java
@@ -28,4 +28,17 @@ public class HomeController {
 		return "redirect:/index.html";
 	}
 
+	@RequestMapping("/item/**")
+	public String item() {
+		return forwardToIndexHtml();
+	}
+
+	@RequestMapping("/item-redirect/**")
+	public String itemRedirect() {
+		return forwardToIndexHtml();
+	}
+
+	private String forwardToIndexHtml() {
+		return "forward:/index.html";
+	}
 }


### PR DESCRIPTION
The HomeController needs mappings for whatever routes could come from a user directly hitting it via a bookmark or copy paste.  I looked at the routes defined in the angular app and saw "/item" and "/item-redirect" so I mapped those.  Possibly we don't need "item-redirect" as it might not be possible for a user to directly hit those.  Should I remove that one?

We need to be aware of this as we introduce new routes.  One thought is all routes start with "/item/"  that way the addition in HomeController will cover everything going forward.