### PR TITLE
Add Logger to be used instead of calls to console.log.  General cleanup.

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -13,15 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-import { Component } from '@angular/core';
+import {Component} from "@angular/core";
 
 @Component({
   selector: 'app-root',
   templateUrl: 'app.component.html',
   styleUrls: ['.//app.component.less']
 })
-
-export class AppComponent {}
-
-
+export class AppComponent {
+}

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -13,60 +13,59 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import {BrowserModule} from "@angular/platform-browser";
+import {NgModule} from "@angular/core";
+import {FormsModule, ReactiveFormsModule} from "@angular/forms";
+import {HttpModule} from "@angular/http";
 
-import {BrowserModule} from '@angular/platform-browser';
-import {NgModule} from '@angular/core';
-import {FormsModule, ReactiveFormsModule} from '@angular/forms';
-import {HttpModule} from '@angular/http';
+import {BsDropdownModule} from "ngx-bootstrap/dropdown";
+import {ModalModule} from "ngx-bootstrap/modal";
+import {AlertModule} from "ngx-bootstrap/alert";
+import {Ng2BootstrapModule} from "ngx-bootstrap/ng2-bootstrap";
 
-import {BsDropdownModule} from 'ngx-bootstrap/dropdown';
-import {ModalModule} from 'ngx-bootstrap/modal';
-import {AlertModule} from 'ngx-bootstrap/alert';
-import {Ng2BootstrapModule} from 'ngx-bootstrap/ng2-bootstrap';
-
-import {AppRoutingModule} from './app.routing';
-import {AppComponent} from './app.component';
-import {HeaderComponent} from './header/header.component';
-import {FooterComponent} from './footer/footer.component';
-import {ItemSelectTypeComponent} from './item/item-create/item-select-type/item-select-type.component';
-import {HomeComponent} from './home/home.component';
-import {ItemCreateComponent} from './item/item-create/item-create.component';
-import {ItemLoadSaComponent} from './item/item-load-sa/item-load-sa.component';
-import {ItemLoadComponent} from './item/item-load/item-load.component';
-import {ItemRedirectComponent} from './item/item-redirect/item-redirect.component';
-import {NoRouteComponent} from './no-route/no-route.component';
+import {AppRoutingModule} from "./app.routing";
+import {AppComponent} from "./app.component";
+import {HeaderComponent} from "./header/header.component";
+import {FooterComponent} from "./footer/footer.component";
+import {ItemSelectTypeComponent} from "./item/item-create/item-select-type/item-select-type.component";
+import {HomeComponent} from "./home/home.component";
+import {ItemCreateComponent} from "./item/item-create/item-create.component";
+import {ItemLoadSaComponent} from "./item/item-load-sa/item-load-sa.component";
+import {ItemLoadComponent} from "./item/item-load/item-load.component";
+import {ItemRedirectComponent} from "./item/item-redirect/item-redirect.component";
+import {NoRouteComponent} from "./no-route/no-route.component";
 import {Logger} from "./utility/logger";
 
 @NgModule({
-    declarations: [
-        AppComponent,
-        FooterComponent,
-        HeaderComponent,
-        HomeComponent,
-        ItemSelectTypeComponent,
-        ItemCreateComponent,
-        ItemLoadSaComponent,
-        ItemLoadComponent,
-        ItemRedirectComponent,
-        NoRouteComponent
-    ],
-    imports: [
-        BrowserModule,
-        FormsModule,
-        ReactiveFormsModule,
-        HttpModule,
-        AppRoutingModule,
-        BsDropdownModule.forRoot(),
-        ModalModule.forRoot(),
-        AlertModule.forRoot(),
-        Ng2BootstrapModule.forRoot()
-    ],
-    providers: [
-      Logger
-    ],
-    bootstrap: [
-      AppComponent
-    ]
+  declarations: [
+    AppComponent,
+    FooterComponent,
+    HeaderComponent,
+    HomeComponent,
+    ItemSelectTypeComponent,
+    ItemCreateComponent,
+    ItemLoadSaComponent,
+    ItemLoadComponent,
+    ItemRedirectComponent,
+    NoRouteComponent
+  ],
+  imports: [
+    BrowserModule,
+    FormsModule,
+    ReactiveFormsModule,
+    HttpModule,
+    AppRoutingModule,
+    BsDropdownModule.forRoot(),
+    ModalModule.forRoot(),
+    AlertModule.forRoot(),
+    Ng2BootstrapModule.forRoot()
+  ],
+  providers: [
+    Logger
+  ],
+  bootstrap: [
+    AppComponent
+  ]
 })
 export class AppModule {
 }

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -35,6 +35,7 @@ import {ItemLoadSaComponent} from './item/item-load-sa/item-load-sa.component';
 import {ItemLoadComponent} from './item/item-load/item-load.component';
 import {ItemRedirectComponent} from './item/item-redirect/item-redirect.component';
 import {NoRouteComponent} from './no-route/no-route.component';
+import {Logger} from "./utility/logger";
 
 @NgModule({
     declarations: [
@@ -60,8 +61,12 @@ import {NoRouteComponent} from './no-route/no-route.component';
         AlertModule.forRoot(),
         Ng2BootstrapModule.forRoot()
     ],
-    providers: [],
-    bootstrap: [AppComponent]
+    providers: [
+      Logger
+    ],
+    bootstrap: [
+      AppComponent
+    ]
 })
 export class AppModule {
 }

--- a/src/app/app.routing.ts
+++ b/src/app/app.routing.ts
@@ -1,26 +1,38 @@
-/**
- * Created by alexponce on 4/28/17.
+/*
+ * Copyright 2017 Regents of the University of California.
+ *
+ * Licensed under the Educational Community License, Version 2.0 (the "license");
+ * you may not use this file except in compliance with the License. You may
+ * obtain a copy of the license at
+ *
+ * https://opensource.org/licenses/ECL-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-import { NgModule } from '@angular/core';
-import { RouterModule, Routes } from '@angular/router';
-import { HomeComponent } from './home/home.component';
-import { ItemSelectTypeComponent } from './item/item-create/item-select-type/item-select-type.component';
-import { ItemCreateComponent } from './item/item-create/item-create.component';
-import { ItemLoadComponent } from './item/item-load/item-load.component';
-import { ItemRedirectComponent } from './item/item-redirect/item-redirect.component';
-import { NoRouteComponent } from './no-route/no-route.component';
+import {NgModule} from "@angular/core";
+import {RouterModule, Routes} from "@angular/router";
+import {HomeComponent} from "./home/home.component";
+import {ItemSelectTypeComponent} from "./item/item-create/item-select-type/item-select-type.component";
+import {ItemCreateComponent} from "./item/item-create/item-create.component";
+import {ItemLoadComponent} from "./item/item-load/item-load.component";
+import {ItemRedirectComponent} from "./item/item-redirect/item-redirect.component";
+import {NoRouteComponent} from "./no-route/no-route.component";
 
 const routes: Routes = [
-  { path: '',                         component: HomeComponent },
-  { path: 'item/:id',                 component: ItemLoadComponent } ,
-  { path: 'item-redirect/:id',        component: ItemRedirectComponent },
-  { path: 'item/create/select-type',  component: ItemSelectTypeComponent },
-  { path: 'item/create/:type',        component: ItemCreateComponent },
-  { path: 'unavailable',              component: NoRouteComponent },
-  { path: '**',                       component: NoRouteComponent }
+  {path: '', component: HomeComponent},
+  {path: 'item/:id', component: ItemLoadComponent},
+  {path: 'item-redirect/:id', component: ItemRedirectComponent},
+  {path: 'item/create/select-type', component: ItemSelectTypeComponent},
+  {path: 'item/create/:type', component: ItemCreateComponent},
+  {path: 'unavailable', component: NoRouteComponent},
+  {path: '**', component: NoRouteComponent}
   /*
    { path: '', redirectTo: '/home-bar', pathMatch: 'full' },
-  */
+   */
 ];
 
 @NgModule({
@@ -31,4 +43,5 @@ const routes: Routes = [
     RouterModule
   ]
 })
-export class AppRoutingModule {}
+export class AppRoutingModule {
+}

--- a/src/app/footer/footer.component.ts
+++ b/src/app/footer/footer.component.ts
@@ -1,5 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import { LookupService } from '../service/lookup.service';
+import {Logger} from "../utility/logger";
 
 @Component({
   selector: 'app-footer',
@@ -15,7 +16,10 @@ export class FooterComponent implements OnInit {
     return this._buildInfo;
   }
 
-  constructor(private lookupService: LookupService) {
+  constructor(
+    private logger: Logger,
+    private lookupService: LookupService
+  ) {
     this.lookupService.getBuildInfo()
       .subscribe((res: Response) => {
         this._buildInfo = res.json();
@@ -27,5 +31,4 @@ export class FooterComponent implements OnInit {
 
   ngOnInit() {
   }
-
 }

--- a/src/app/footer/footer.component.ts
+++ b/src/app/footer/footer.component.ts
@@ -1,6 +1,20 @@
-import { Component, OnInit } from '@angular/core';
-import { LookupService } from '../service/lookup.service';
-import {Logger} from "../utility/logger";
+/*
+ * Copyright 2017 Regents of the University of California.
+ *
+ * Licensed under the Educational Community License, Version 2.0 (the "license");
+ * you may not use this file except in compliance with the License. You may
+ * obtain a copy of the license at
+ *
+ * https://opensource.org/licenses/ECL-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {Component} from "@angular/core";
+import {LookupService} from "../service/lookup.service";
 
 @Component({
   selector: 'app-footer',
@@ -8,27 +22,19 @@ import {Logger} from "../utility/logger";
   styleUrls: ['./footer.component.less'],
   providers: [LookupService]
 })
-export class FooterComponent implements OnInit {
-
+export class FooterComponent {
   private _buildInfo: any;
-
   get buildInfo(): any {
     return this._buildInfo;
   }
 
-  constructor(
-    private logger: Logger,
-    private lookupService: LookupService
-  ) {
+  constructor(private lookupService: LookupService) {
     this.lookupService.getBuildInfo()
       .subscribe((res: Response) => {
-        this._buildInfo = res.json();
-      },
-      () => {
-        this._buildInfo = '';
-      });
-  }
-
-  ngOnInit() {
+          this._buildInfo = res.json();
+        },
+        () => {
+          this._buildInfo = '';
+        });
   }
 }

--- a/src/app/header/header.component.ts
+++ b/src/app/header/header.component.ts
@@ -13,36 +13,33 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-import {Component, OnInit} from '@angular/core';
-import {Response} from '@angular/http';
-import {LookupService} from '../service/lookup.service';
+import {Component} from "@angular/core";
+import {Response} from "@angular/http";
+import {LookupService} from "../service/lookup.service";
 import {Logger} from "../utility/logger";
 
 @Component({
-    selector: 'app-header',
-    templateUrl: 'header.component.html',
-    styleUrls: ['./header.component.less'],
-    providers: [LookupService]
+  selector: 'app-header',
+  templateUrl: 'header.component.html',
+  styleUrls: ['./header.component.less'],
+  providers: [LookupService]
 })
 export class HeaderComponent {
+  private _user: any;  // TODO: Strongly type
+  get user(): any {
+    return this._user;
+  }
 
-    isCollapsed = true;
+  constructor(private logger: Logger,
+              private lookupService: LookupService) {
+    this.lookupService.getUser()
+      .subscribe((res: Response) => {
+        this._user = res.json();
+      });
+  }
 
-    user: any;
-
-    constructor(
-      private logger: Logger,
-      private lookupService: LookupService
-    ) {
-        this.lookupService.getUser()
-            .subscribe((res: Response) => {
-                this.user = res.json();
-            });
-    }
-
-    logOut() {
-        this.logger.debug('logging out...');
-        window.location.href = '/saml/logout';
-    }
+  logOut(): void {
+    this.logger.debug('logging out...');
+    window.location.href = '/saml/logout';
+  }
 }

--- a/src/app/header/header.component.ts
+++ b/src/app/header/header.component.ts
@@ -17,6 +17,7 @@
 import {Component, OnInit} from '@angular/core';
 import {Response} from '@angular/http';
 import {LookupService} from '../service/lookup.service';
+import {Logger} from "../utility/logger";
 
 @Component({
     selector: 'app-header',
@@ -30,7 +31,10 @@ export class HeaderComponent {
 
     user: any;
 
-    constructor(private lookupService: LookupService) {
+    constructor(
+      private logger: Logger,
+      private lookupService: LookupService
+    ) {
         this.lookupService.getUser()
             .subscribe((res: Response) => {
                 this.user = res.json();
@@ -38,11 +42,7 @@ export class HeaderComponent {
     }
 
     logOut() {
-        console.log('logging out...');
+        this.logger.debug('logging out...');
         window.location.href = '/saml/logout';
     }
-
-    // ------------------------------------------------------------------------
-
-
 }

--- a/src/app/header/header.component.ts
+++ b/src/app/header/header.component.ts
@@ -25,6 +25,7 @@ import {Logger} from "../utility/logger";
   providers: [LookupService]
 })
 export class HeaderComponent {
+  public isCollapsed = true; // TODO: confirm if this value is needed
   private _user: any;  // TODO: Strongly type
   get user(): any {
     return this._user;

--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -1,4 +1,5 @@
 import {Component, OnInit} from '@angular/core';
+import {Logger} from "../utility/logger";
 
 @Component({
   selector: 'app-home',
@@ -7,11 +8,11 @@ import {Component, OnInit} from '@angular/core';
 })
 
 export class HomeComponent implements OnInit {
-
-  constructor() {
+  constructor(
+    private logger: Logger
+  ) {
   }
 
   ngOnInit() {
   }
-
 }

--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -1,18 +1,24 @@
-import {Component, OnInit} from '@angular/core';
-import {Logger} from "../utility/logger";
+/*
+ * Copyright 2017 Regents of the University of California.
+ *
+ * Licensed under the Educational Community License, Version 2.0 (the "license");
+ * you may not use this file except in compliance with the License. You may
+ * obtain a copy of the license at
+ *
+ * https://opensource.org/licenses/ECL-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {Component} from "@angular/core";
 
 @Component({
   selector: 'app-home',
   templateUrl: './home.component.html',
   styleUrls: ['./home.component.less']
 })
-
-export class HomeComponent implements OnInit {
-  constructor(
-    private logger: Logger
-  ) {
-  }
-
-  ngOnInit() {
-  }
+export class HomeComponent {
 }

--- a/src/app/item/item-create/item-create.component.spec.ts
+++ b/src/app/item/item-create/item-create.component.spec.ts
@@ -5,6 +5,7 @@ import {AlertModule} from 'ngx-bootstrap/alert';
 import {LookupService} from '../../service/lookup.service';
 import {ItemService} from '../../service/item.service';
 import {ItemCreateComponent} from './item-create.component';
+import {Logger} from "../../utility/logger";
 
 describe('ItemCreateComponent', () => {
     let component: ItemCreateComponent;
@@ -22,7 +23,8 @@ describe('ItemCreateComponent', () => {
             ],
             providers: [
                 LookupService,
-                ItemService
+                ItemService,
+                Logger
             ]
         })
             .compileComponents();

--- a/src/app/item/item-create/item-create.component.ts
+++ b/src/app/item/item-create/item-create.component.ts
@@ -1,7 +1,22 @@
-import 'rxjs/add/operator/switchMap';
-import {Component, OnInit} from '@angular/core';
-import {ActivatedRoute, Router} from '@angular/router';
-import {ItemService} from '../../service/item.service';
+/*
+ * Copyright 2017 Regents of the University of California.
+ *
+ * Licensed under the Educational Community License, Version 2.0 (the "license");
+ * you may not use this file except in compliance with the License. You may
+ * obtain a copy of the license at
+ *
+ * https://opensource.org/licenses/ECL-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import "rxjs/add/operator/switchMap";
+import {Component, OnInit} from "@angular/core";
+import {ActivatedRoute, Router} from "@angular/router";
+import {ItemService} from "../../service/item.service";
 import {Logger} from "../../utility/logger";
 
 @Component({
@@ -13,26 +28,23 @@ import {Logger} from "../../utility/logger";
   ]
 })
 export class ItemCreateComponent implements OnInit {
+  private itemType: string;
 
-  private _itemType: string;
-  private _errorMessage: string;
+  private errorMessage: string;
 
-  constructor(
-    private logger: Logger,
-    private router: Router,
-    private route: ActivatedRoute,
-    private itemService: ItemService
-  ) { }
+  constructor(private logger: Logger,
+              private router: Router,
+              private route: ActivatedRoute,
+              private itemService: ItemService) {
+  }
 
   ngOnInit() {
-
     this.route.params
       .subscribe(params => {
-        this._itemType = params['type'];
+        this.itemType = params['type'];
       });
 
-
-    this.itemService.beginItemCreate(this._itemType)
+    this.itemService.beginItemCreate(this.itemType)
       .subscribe(
         item => this.processSuccess(item),
         error => this.processError(error),
@@ -40,16 +52,14 @@ export class ItemCreateComponent implements OnInit {
       );
   }
 
-  private processSuccess(item): void {
+  private processSuccess(item): void {  // TODO: Strongly type parameter
     // TODO: Add validation
     const itemId = item.id;
 
     this.router.navigateByUrl('/item/' + itemId);
   }
 
-  private processError(error): void {
-    this._errorMessage = error;
+  private processError(error): void {   // TODO: Strongly type parameter
+    this.errorMessage = error;
   }
-
 }
-

--- a/src/app/item/item-create/item-create.component.ts
+++ b/src/app/item/item-create/item-create.component.ts
@@ -2,6 +2,7 @@ import 'rxjs/add/operator/switchMap';
 import {Component, OnInit} from '@angular/core';
 import {ActivatedRoute, Router} from '@angular/router';
 import {ItemService} from '../../service/item.service';
+import {Logger} from "../../utility/logger";
 
 @Component({
   selector: 'app-item-create',
@@ -16,10 +17,12 @@ export class ItemCreateComponent implements OnInit {
   private _itemType: string;
   private _errorMessage: string;
 
-  constructor(private router: Router,
-              private route: ActivatedRoute,
-              private itemService: ItemService) {
-  }
+  constructor(
+    private logger: Logger,
+    private router: Router,
+    private route: ActivatedRoute,
+    private itemService: ItemService
+  ) { }
 
   ngOnInit() {
 
@@ -33,7 +36,7 @@ export class ItemCreateComponent implements OnInit {
       .subscribe(
         item => this.processSuccess(item),
         error => this.processError(error),
-        () => console.log('scratchpad item created successfully')
+        () => this.logger.debug('scratchpad item created successfully')
       );
   }
 

--- a/src/app/item/item-create/item-select-type/item-select-type.component.spec.ts
+++ b/src/app/item/item-create/item-select-type/item-select-type.component.spec.ts
@@ -3,6 +3,7 @@ import { HttpModule } from '@angular/http';
 import { ItemSelectTypeComponent } from './item-select-type.component';
 import { LookupService} from '../../../service/lookup.service';
 import { RouterTestingModule} from '@angular/router/testing';
+import {Logger} from "../../../utility/logger";
 
 describe('ItemSelectTypeComponent', () => {
 
@@ -16,7 +17,8 @@ describe('ItemSelectTypeComponent', () => {
         RouterTestingModule
       ],
       providers: [
-        LookupService
+        LookupService,
+        Logger
       ]
     }).compileComponents();
   }));

--- a/src/app/item/item-create/item-select-type/item-select-type.component.ts
+++ b/src/app/item/item-create/item-select-type/item-select-type.component.ts
@@ -1,7 +1,22 @@
-import {Component, OnInit} from '@angular/core';
-import {Router} from '@angular/router';
-import {LookupService} from '../../../service/lookup.service';
-import {ItemType} from '../../../model/item-type';
+/*
+ * Copyright 2017 Regents of the University of California.
+ *
+ * Licensed under the Educational Community License, Version 2.0 (the "license");
+ * you may not use this file except in compliance with the License. You may
+ * obtain a copy of the license at
+ *
+ * https://opensource.org/licenses/ECL-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {Component, OnInit} from "@angular/core";
+import {Router} from "@angular/router";
+import {LookupService} from "../../../service/lookup.service";
+import {ItemType} from "../../../model/item-type";
 import {Logger} from "../../../utility/logger";
 
 @Component({
@@ -11,23 +26,28 @@ import {Logger} from "../../../utility/logger";
   providers: [LookupService]
 })
 export class ItemSelectTypeComponent implements OnInit {
+  private _items: ItemType[];
+  get items(): ItemType[] {
+    return this._items;
+  }
 
-  items: ItemType[];
-  other: ItemType[];
+  private _other: ItemType[];
+  get other(): ItemType[] {
+    return this._other;
+  }
 
-  constructor(
-    private logger: Logger,
-    private router: Router,
-    private lookupService: LookupService
-  ) { }
+  constructor(private logger: Logger,
+              private router: Router,
+              private lookupService: LookupService) {
+  }
 
   ngOnInit() {
-    this.items = this.lookupService.getMainItemTypes();
-    this.other = this.lookupService.getOtherItemTypes();
+    this._items = this.lookupService.getMainItemTypes();
+    this._other = this.lookupService.getOtherItemTypes();
   }
 
   confirmCancel(): void {
-      this.logger.debug('cancel item select type...');
-      this.router.navigateByUrl('/');
+    this.logger.debug('cancel item select type...');
+    this.router.navigateByUrl('/');
   }
 }

--- a/src/app/item/item-create/item-select-type/item-select-type.component.ts
+++ b/src/app/item/item-create/item-select-type/item-select-type.component.ts
@@ -2,6 +2,7 @@ import {Component, OnInit} from '@angular/core';
 import {Router} from '@angular/router';
 import {LookupService} from '../../../service/lookup.service';
 import {ItemType} from '../../../model/item-type';
+import {Logger} from "../../../utility/logger";
 
 @Component({
   selector: 'app-item-select-type',
@@ -14,9 +15,11 @@ export class ItemSelectTypeComponent implements OnInit {
   items: ItemType[];
   other: ItemType[];
 
-  constructor(private router: Router,
-              private lookupService: LookupService) {
-  }
+  constructor(
+    private logger: Logger,
+    private router: Router,
+    private lookupService: LookupService
+  ) { }
 
   ngOnInit() {
     this.items = this.lookupService.getMainItemTypes();
@@ -24,7 +27,7 @@ export class ItemSelectTypeComponent implements OnInit {
   }
 
   confirmCancel(): void {
-      console.log('cancel item select type...');
+      this.logger.debug('cancel item select type...');
       this.router.navigateByUrl('/');
   }
 }

--- a/src/app/item/item-load-sa/item-load-sa.component.html
+++ b/src/app/item/item-load-sa/item-load-sa.component.html
@@ -53,6 +53,7 @@
         </div>
     </div>
 </div>
+<!-- TODO: Move dialog to separate component: DialogComponent -->
 <!-- Modal -->
 <div id="deleteExemplarResponse" class="modal fade" bsModal #deleteExemplarResponse="bs-modal"
      [config]="{backdrop: 'static'}"

--- a/src/app/item/item-load-sa/item-load-sa.component.spec.ts
+++ b/src/app/item/item-load-sa/item-load-sa.component.spec.ts
@@ -3,6 +3,7 @@ import { RouterTestingModule} from '@angular/router/testing';
 import { ReactiveFormsModule} from '@angular/forms';
 import { ModalModule } from 'ngx-bootstrap/modal';
 import { ItemLoadSaComponent } from './item-load-sa.component';
+import {Logger} from "../../utility/logger";
 
 describe('ItemCreateSaComponent', () => {
   let component: ItemLoadSaComponent;
@@ -17,6 +18,9 @@ describe('ItemCreateSaComponent', () => {
       ],
       declarations: [
         ItemLoadSaComponent
+      ],
+      providers: [
+        Logger
       ]
     })
     .compileComponents();

--- a/src/app/item/item-load-sa/item-load-sa.component.ts
+++ b/src/app/item/item-load-sa/item-load-sa.component.ts
@@ -2,6 +2,7 @@ import {isNumeric} from 'rxjs/util/isNumeric';
 import { Component, OnInit, Input } from '@angular/core';
 import { Content, Item, Rubric, Sample} from '../../model/item';
 import { FormArray, FormControl, FormGroup, FormBuilder, ReactiveFormsModule} from '@angular/forms';
+import {Logger} from "../../utility/logger";
 
 @Component({
   selector: 'app-item-load-sa',
@@ -16,6 +17,16 @@ export class ItemLoadSaComponent implements OnInit {
   private _nextResponseId: number;       // TODO: Is this needed?  Why not use _itemResponses count instead? Remove this field if possible
   private _deleteResponseId: number;     // TODO:
   public stemForm: FormGroup;
+
+  constructor(
+    private logger: Logger
+  ) {
+    // this.stemForm = new FormGroup(
+    //   {
+    //     promptStem: new FormControl()
+    //   }
+    // );
+  }
 
   @Input()
   set item(item) {
@@ -50,10 +61,8 @@ export class ItemLoadSaComponent implements OnInit {
           }
         }
       }
-
     }
   }
-
 
   get item() {
     return this._item;
@@ -73,16 +82,6 @@ export class ItemLoadSaComponent implements OnInit {
 
   get deleteResponseId(): number {
     return this._deleteResponseId;
-  }
-
-
-
-  constructor() {
-    // this.stemForm = new FormGroup(
-    //   {
-    //     promptStem: new FormControl()
-    //   }
-    // );
   }
 
   ngOnInit() {
@@ -114,8 +113,6 @@ export class ItemLoadSaComponent implements OnInit {
       }
     }
 
-    // console.log('controls: ' + this.stemForm.contains("responses"));
-
     return this.item;
   }
 
@@ -129,20 +126,18 @@ export class ItemLoadSaComponent implements OnInit {
     resp.samplecontent = '';
     resp.scorepoint = null;
 
-    console.log('new id: ' + resp.id);
+    this.logger.debug('new id: ' + resp.id);
 
     this.itemResponses.push(resp);
 
   }
 
   removeResponse(): void {
-    // console.log('item to delete: ' + this.deleteResponseId)
     if (this.deleteResponseId !== 0) {
       this._itemResponses = this.itemResponses.filter(
         response => response.id !== this.deleteResponseId
       );
       this.setDeleteResponseId(0);
     }
-    // console.log('current delete Id: ' + this.deleteResponseId)
   }
 }

--- a/src/app/item/item-load-sa/item-load-sa.component.ts
+++ b/src/app/item/item-load-sa/item-load-sa.component.ts
@@ -1,7 +1,22 @@
-import {isNumeric} from 'rxjs/util/isNumeric';
-import { Component, OnInit, Input } from '@angular/core';
-import { Content, Item, Rubric, Sample} from '../../model/item';
-import { FormArray, FormControl, FormGroup, FormBuilder, ReactiveFormsModule} from '@angular/forms';
+/*
+ * Copyright 2017 Regents of the University of California.
+ *
+ * Licensed under the Educational Community License, Version 2.0 (the "license");
+ * you may not use this file except in compliance with the License. You may
+ * obtain a copy of the license at
+ *
+ * https://opensource.org/licenses/ECL-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {isNumeric} from "rxjs/util/isNumeric";
+import {Component, Input, OnInit} from "@angular/core";
+import {Content, Item, Rubric, Sample} from "../../model/item";
+import {FormControl, FormGroup} from "@angular/forms";
 import {Logger} from "../../utility/logger";
 
 @Component({
@@ -10,24 +25,11 @@ import {Logger} from "../../utility/logger";
   styleUrls: ['./item-load-sa.component.less']
 })
 export class ItemLoadSaComponent implements OnInit {
-
+  // TODO: Nasty logic in the set function.  Move this to the Item constructor and add the necessary properties to Item to expose the data being populated in this set function.
   private _item = new Item();
-  private _itemContent = new Content();  // TODO: Does this field refer to a sub-object in _item? Remove this field and use sub-object in _item instead; confusing to track parts of item in separate fields
-  private _itemResponses: Sample[] = []; // TODO: Does this field refer to a sub-object in _item? Remove this field and use sub-object in _item instead; confusing to track parts of item in separate fields
-  private _nextResponseId: number;       // TODO: Is this needed?  Why not use _itemResponses count instead? Remove this field if possible
-  private _deleteResponseId: number;     // TODO:
-  public stemForm: FormGroup;
-
-  constructor(
-    private logger: Logger
-  ) {
-    // this.stemForm = new FormGroup(
-    //   {
-    //     promptStem: new FormControl()
-    //   }
-    // );
+  get item() {
+    return this._item;
   }
-
   @Input()
   set item(item) {
     this._item = item;
@@ -54,8 +56,8 @@ export class ItemLoadSaComponent implements OnInit {
 
             if (this.itemResponses instanceof Array) {
               for (const response of this.itemResponses) {
-                this._nextResponseId ++;
-                response.id = this._nextResponseId;
+                this.nextResponseId++;
+                response.id = this.nextResponseId;
               }
             }
           }
@@ -64,29 +66,40 @@ export class ItemLoadSaComponent implements OnInit {
     }
   }
 
-  get item() {
-    return this._item;
-  }
-
+  // TODO: Does this field refer to a sub-object in _item? Remove this field and use sub-object in _item instead; confusing to track parts of item in separate fields
+  private _itemContent = new Content();
   get itemContent(): Content {
     return this._itemContent;
   }
 
+  // TODO: Does this field refer to a sub-object in _item? Remove this field and use sub-object in _item instead; confusing to track parts of item in separate fields
+  private _itemResponses: Sample[] = [];
   get itemResponses(): any[] {
     return this._itemResponses;
   }
 
+  // TODO: Move this to be a method on the Item type
   get itemAttributes(): string {
     return JSON.stringify(this.item.attributes);
   }
 
+  private _deleteResponseId: number;
   get deleteResponseId(): number {
     return this._deleteResponseId;
   }
 
+  // TODO: This field shouldn't be needed. Why not use _itemResponses count instead? Remove this field if possible.
+  private nextResponseId: number;
+
+  // TODO: Make this private and add public get method
+  stemForm: FormGroup;
+
+  constructor(private logger: Logger) {
+  }
+
   ngOnInit() {
     this._deleteResponseId = 0;
-    this._nextResponseId = 0;
+    this.nextResponseId = 0;
 
     this.stemForm = new FormGroup(
       {
@@ -95,14 +108,15 @@ export class ItemLoadSaComponent implements OnInit {
     );
   }
 
-  public setDeleteResponseId(id: number): void {
-    if ( isNumeric(id) ) {  // TODO: Why is this check necessary? Remove if possible
+  // TODO: Function named with "set" prefix should be a property setter instead of a regular function
+  setDeleteResponseId(id: number): void {
+    if (isNumeric(id)) {  // TODO: Why is this check necessary? Remove if possible
       this._deleteResponseId = id;
     }
   }
 
-  public getUpdatedItem(): Item {
-
+  // TODO: Function named with "get" prefix should be a property getter instead of a regular function
+  getUpdatedItem(): Item {
     const enuRubric = new Rubric();
     enuRubric.name = 'ExemplarResponse';
 
@@ -117,10 +131,10 @@ export class ItemLoadSaComponent implements OnInit {
   }
 
   addResponse(): void {
-    this._nextResponseId ++;
+    this.nextResponseId++;
 
     const resp = new Sample();
-    resp.id = this._nextResponseId;
+    resp.id = this.nextResponseId;
     resp.name = 'Exemplar';
     resp.purpose = 'Exemplar';
     resp.samplecontent = '';

--- a/src/app/item/item-load/item-load.component.spec.ts
+++ b/src/app/item/item-load/item-load.component.spec.ts
@@ -2,12 +2,11 @@ import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { HttpModule } from '@angular/http';
 import { ReactiveFormsModule} from '@angular/forms';
 import { RouterTestingModule} from '@angular/router/testing';
-
 import { AlertModule } from 'ngx-bootstrap/alert';
 import { ModalModule } from 'ngx-bootstrap/modal';
-
 import { ItemLoadSaComponent} from '../item-load-sa/item-load-sa.component';
 import { ItemLoadComponent } from './item-load.component';
+import {Logger} from "../../utility/logger";
 
 describe('ItemLoadComponent', () => {
   let component: ItemLoadComponent;
@@ -25,6 +24,9 @@ describe('ItemLoadComponent', () => {
       declarations: [
         ItemLoadComponent,
         ItemLoadSaComponent
+      ],
+      providers: [
+        Logger
       ]
     })
     .compileComponents();

--- a/src/app/item/item-load/item-load.component.ts
+++ b/src/app/item/item-load/item-load.component.ts
@@ -1,10 +1,25 @@
-import { isNumeric } from 'rxjs/util/isNumeric';
-import { AfterViewInit, Component, OnInit, ViewChild } from '@angular/core';
-import { Router, ActivatedRoute } from '@angular/router';
-import { LookupService } from '../../service/lookup.service';
-import { Item } from '../../model/item';
-import { ItemService } from '../../service/item.service';
-import { ItemLoadSaComponent } from '../item-load-sa/item-load-sa.component';
+/*
+ * Copyright 2017 Regents of the University of California.
+ *
+ * Licensed under the Educational Community License, Version 2.0 (the "license");
+ * you may not use this file except in compliance with the License. You may
+ * obtain a copy of the license at
+ *
+ * https://opensource.org/licenses/ECL-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {isNumeric} from "rxjs/util/isNumeric";
+import {Component, OnInit, ViewChild} from "@angular/core";
+import {ActivatedRoute, Router} from "@angular/router";
+import {LookupService} from "../../service/lookup.service";
+import {Item} from "../../model/item";
+import {ItemService} from "../../service/item.service";
+import {ItemLoadSaComponent} from "../item-load-sa/item-load-sa.component";
 import {Logger} from "../../utility/logger";
 
 // TODO: Move stem-related code into separate component (called StemComponent)
@@ -12,239 +27,229 @@ import {Logger} from "../../utility/logger";
 // TODO: Move nav bar message-related code into separate component (called ItemHeaderComponent)
 
 @Component({
-    selector: 'app-item-load',
-    templateUrl: './item-load.component.html',
-    styleUrls: ['./item-load.component.less'],
-    providers: [
-        LookupService,
-        ItemService
-    ]
+  selector: 'app-item-load',
+  templateUrl: './item-load.component.html',
+  styleUrls: ['./item-load.component.less'],
+  providers: [
+    LookupService,
+    ItemService
+  ]
 })
-// TODO: Does this need to implement AfterViewInit?  Implementation of that method does nothing (see later)
-export class ItemLoadComponent implements OnInit, AfterViewInit {
-    private _currentItemId: number;
-    private _currentItem = new Item();
-    private _navBarMessage: string;
-    private _user: any; // TODO: Strongly type (looks like you only use username so consider changing this field to a non-nullable string "_currentUsername")
-    private _loading: boolean;
-    private _serviceError: boolean;
-    private _errorMessage: string;
+// TODO: This class has too many fields - clear sign it needs to be factored into multiple classes
+export class ItemLoadComponent implements OnInit {
+  private currentItemId: number;
 
-    @ViewChild(ItemLoadSaComponent) saItemComponent;
+  private _currentItem = new Item();
+  get currentItem(): Item {
+    return this._currentItem;
+  }
 
-    constructor(
-      private logger: Logger,
-      private router: Router,
-      private route: ActivatedRoute,
-      private lookupService: LookupService,
-      private itemService: ItemService
-    ) { }
+  private _navBarMessage: string;
+  get navBarMessage(): string {
+    return this._navBarMessage;
+  }
 
-    ngOnInit() {
-        this._loading = true;
-        this._serviceError = false;
+  private _user: any; // TODO: Strongly type (looks like only the username is used so consider changing this field to a non-nullable string "_currentUsername")
+  get user(): any {
+    return this._user;
+  }
 
-        this.route.params
-            .subscribe(params => {
-                this._currentItemId = params['id'];
-            });
+  private _loading: boolean;
+  get loading(): boolean {
+    return this._loading;
+  }
 
-        this.logger.debug('id: ' + this._currentItemId);
+  private _serviceError: boolean;
+  get serviceError(): boolean {
+    return this._serviceError;
+  }
 
-        if (isNumeric(this._currentItemId)) {
-            this.lookupService.getUser()
-                .subscribe(
-                    (res: Response) => {
-                        this._user = res.json();
-                    },
-                    error => this.logger.error(error),
-                    () => {
-                        this.itemService.findItem(this._currentItemId)
-                            .subscribe(
-                                item => this.onSuccess(item),
-                                error => this.onError(error),
-                                () => {
-                                    this._loading = false;
-                                }
-                            );
-                    });
-        } else {
-            this._loading = false;
-            this.router.navigateByUrl('/unavailable');
-        }
-    }
+  private _errorMessage: string;
+  get errorMessage(): string {
+    return this._errorMessage;
+  }
 
-    // TODO: Is this needed?  If not remove
-    ngAfterViewInit() {}
+  @ViewChild(ItemLoadSaComponent) saItemComponent;
 
-    public createItem(): void {
-      this.logger.debug('creating item: ' + JSON.stringify(this.saItemComponent.getUpdatedItem()));
-      // TODO: What if this fails?  Need to not redirect to / on failure
-      this.itemService.commitItemCreate(this.saItemComponent.getUpdatedItem());
-      this.router.navigateByUrl('/');
-    }
+  constructor(private logger: Logger,
+              private router: Router,
+              private route: ActivatedRoute,
+              private lookupService: LookupService,
+              private itemService: ItemService) {
+  }
 
-    public cancelCreate(): void {
-      // TODO: What if this fails?  Need to not redirect to / on failure
-        this.itemService.rollbackItemCreate(this.currentItem.id);
-        this.router.navigateByUrl('/');
-    }
+  ngOnInit() {
+    this._loading = true;
+    this._serviceError = false;
 
-    public editItem(): void {
-        this.itemService.beginItemEdit(this._currentItemId)
-            .subscribe(
+    this.route.params
+      .subscribe(params => {
+        this.currentItemId = params['id'];
+      });
+
+    this.logger.debug('id: ' + this.currentItemId);
+
+    if (isNumeric(this.currentItemId)) {
+      this.lookupService.getUser()
+        .subscribe(
+          (res: Response) => {
+            this._user = res.json();
+          },
+          error => this.logger.error(error),
+          () => {
+            this.itemService.findItem(this.currentItemId)
+              .subscribe(
+                item => this.onSuccess(item),
+                error => this.onError(error),
                 () => {
-                    this.router.navigateByUrl('/item-redirect/' + this._currentItemId);
-                },
-                error => this.onError(error)
-            );
+                  this._loading = false;
+                }
+              );
+          });
+    } else {
+      this._loading = false;
+      this.router.navigateByUrl('/unavailable');
     }
+  }
 
-    public cancelEdit(): void {
-      // TODO: What if this fails?  Need to not redirect to / on failure
-        this.itemService.rollbackItemEdit(this.currentItem.id);
-        this.router.navigateByUrl('/');
-    }
+  createItem(): void {
+    this.logger.debug('creating item: ' + JSON.stringify(this.saItemComponent.getUpdatedItem()));
+    // TODO: What if this fails?  Need to not redirect to / on failure
+    this.itemService.commitItemCreate(this.saItemComponent.getUpdatedItem());
+    this.router.navigateByUrl('/');
+  }
 
-    public commitItem(): void {
-      this.logger.debug('committing item: ' + JSON.stringify(this.saItemComponent.getUpdatedItem()));
-      // TODO: What if this fails?  Need to not redirect to / on failure
-      this.itemService.commitItemEdit(this.saItemComponent.getUpdatedItem(), 'IAT generated commit');
-      this.router.navigateByUrl('/');
-    }
+  cancelCreate(): void {
+    // TODO: What if this fails?  Need to not redirect to / on failure
+    this.itemService.rollbackItemCreate(this.currentItem.id);
+    this.router.navigateByUrl('/');
+  }
 
-    public isCreate(): boolean {
-        if (this._user && this._currentItem) {
-            if (this._user.username === this._currentItem.beingCreatedBy
-                && this._currentItem.beingEditedBy === null) {
-                return true;
-            }
-        }
-        return false;
-    }
+  editItem(): void {
+    this.itemService.beginItemEdit(this.currentItemId)
+      .subscribe(
+        () => {
+          this.router.navigateByUrl('/item-redirect/' + this.currentItemId);
+        },
+        error => this.onError(error)
+      );
+  }
 
-    public isView(): boolean {
-        if (this._currentItem) {
-            if (this._currentItem.beingCreatedBy === null
-                && this._currentItem.beingEditedBy === null) {
-                return true;
-            }
-        }
-        return false;
-    }
+  cancelEdit(): void {
+    // TODO: What if this fails?  Need to not redirect to / on failure
+    this.itemService.rollbackItemEdit(this.currentItem.id);
+    this.router.navigateByUrl('/');
+  }
 
-    public isEdit(): boolean {
-        if (this._user && this._currentItem) {
-            if (this._user.username === this._currentItem.beingEditedBy
-                && this._currentItem.beingCreatedBy === null) {
-                return true;
-            }
-        }
-        return false;
-    }
+  commitItem(): void {
+    this.logger.debug('committing item: ' + JSON.stringify(this.saItemComponent.getUpdatedItem()));
+    // TODO: What if this fails?  Need to not redirect to / on failure
+    this.itemService.commitItemEdit(this.saItemComponent.getUpdatedItem(), 'IAT generated commit');
+    this.router.navigateByUrl('/');
+  }
 
-    // TODO: Why isn't this the negation of isEdit?
-    public isNotEditable(): boolean {
-        if (this._user && this._currentItem) {
-            if (this._currentItem.beingCreatedBy === null
-                && this._currentItem.beingEditedBy != null
-                && this._user.username !== this._currentItem.beingEditedBy) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    public goHome(): void {
-      this.router.navigateByUrl('/');
-    }
-
-    private onSuccess(item): void {
-        this.logger.debug('retrieved item: ' + JSON.stringify(item));
-        let navBarMsgPrefix: string;
-        this._currentItem = item;
-        this._currentItem.description = this.lookupService.getItemDescription(this._currentItem.type);
-
-        if (this.isCreate()) {
-            // Item is currently being created by logged in user
-            navBarMsgPrefix = 'Create';
-        }
-        if (this.isView()) {
-            navBarMsgPrefix = 'View';
-        }
-        if (this.isEdit()) {
-            navBarMsgPrefix = 'Edit';
-        }
-
-        this._navBarMessage = navBarMsgPrefix + ' Item ' + this._currentItem.id
-            + ' | ' + this._currentItem.description;
-    }
-
-    private onError(error): void {
-        this._loading = false;
-        this._serviceError = true;
-
-        this.logger.error('Error Status: ' + error.status);
-
-        switch (error.status) {
-          case 400:
-          case 404: {
-            this._errorMessage = this.getErrorMessages(error);
-            break;
-          }
-          case 500: {
-            this._errorMessage = 'Internal Server Error';
-            break;
-          }
-          default: {
-            this._errorMessage = 'Unknown Error';
-          }
-        }
-    }
-
-    private getErrorMessages(error: any): string {
-      const body = error.json() || '';
-      const objMessages = JSON.parse(JSON.stringify(body));
-
-      let msgs: string;
-
-      if (objMessages instanceof Array) {
-        for (const msg of objMessages) {
-          msgs += msg.message;
-        }
+  isCreate(): boolean {
+    if (this._user && this._currentItem) {
+      if (this._user.username === this._currentItem.beingCreatedBy
+        && this._currentItem.beingEditedBy === null) {
+        return true;
       }
+    }
+    return false;
+  }
 
-      return msgs;
+  isView(): boolean {
+    if (this._currentItem) {
+      if (this._currentItem.beingCreatedBy === null
+        && this._currentItem.beingEditedBy === null) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  isEdit(): boolean {
+    if (this._user && this._currentItem) {
+      if (this._user.username === this._currentItem.beingEditedBy
+        && this._currentItem.beingCreatedBy === null) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  // TODO: Why isn't this the negation of isEdit?
+  isNotEditable(): boolean {
+    if (this._user && this._currentItem) {
+      if (this._currentItem.beingCreatedBy === null
+        && this._currentItem.beingEditedBy != null
+        && this._user.username !== this._currentItem.beingEditedBy) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  goHome(): void {
+    this.router.navigateByUrl('/');
+  }
+
+  private onSuccess(item): void {
+    this.logger.debug('retrieved item: ' + JSON.stringify(item));
+    let navBarMsgPrefix: string;
+    this._currentItem = item;
+    this._currentItem.description = this.lookupService.getItemDescription(this._currentItem.type);
+
+    if (this.isCreate()) {
+      // Item is currently being created by logged in user
+      navBarMsgPrefix = 'Create';
+    }
+    if (this.isView()) {
+      navBarMsgPrefix = 'View';
+    }
+    if (this.isEdit()) {
+      navBarMsgPrefix = 'Edit';
     }
 
-    // ------------------------------------------------------
+    this._navBarMessage = navBarMsgPrefix + ' Item ' + this._currentItem.id
+      + ' | ' + this._currentItem.description;
+  }
 
-    get currentItem(): Item {
-        return this._currentItem;
+  private onError(error): void {
+    this._loading = false;
+    this._serviceError = true;
+
+    this.logger.error('Error Status: ' + error.status);
+
+    switch (error.status) {
+      case 400:
+      case 404: {
+        this._errorMessage = this.getErrorMessages(error);
+        break;
+      }
+      case 500: {
+        this._errorMessage = 'Internal Server Error';
+        break;
+      }
+      default: {
+        this._errorMessage = 'Unknown Error';
+      }
+    }
+  }
+
+  // TODO: Function named with "get" prefix shouldn't take parameter (and if it doesn't take parameter it should be a property getter instead of a regular method).  In this case this function should be renamed to something like "toErrorString"
+  private getErrorMessages(error: any): string {
+    const body = error.json() || '';
+    const objMessages = JSON.parse(JSON.stringify(body));
+
+    let msgs: string;
+
+    if (objMessages instanceof Array) {
+      for (const msg of objMessages) {
+        msgs += msg.message;
+      }
     }
 
-    // TODO: Is this used?  If not remove
-    get navBarMessage(): string {
-        return this._navBarMessage;
-    }
-
-    // TODO: Strongly type
-    get user(): any {
-        return this._user;
-    }
-
-  // TODO: Is this used?  If not remove
-    get loading(): boolean {
-        return this._loading;
-    }
-
-  // TODO: Is this used?  If not remove
-    get serviceError(): boolean {
-        return this._serviceError;
-    }
-
-  // TODO: Is this used?  If not remove
-    get errorMessage(): string {
-        return this._errorMessage;
-    }
+    return msgs;
+  }
 }

--- a/src/app/item/item-load/item-load.component.ts
+++ b/src/app/item/item-load/item-load.component.ts
@@ -5,6 +5,7 @@ import { LookupService } from '../../service/lookup.service';
 import { Item } from '../../model/item';
 import { ItemService } from '../../service/item.service';
 import { ItemLoadSaComponent } from '../item-load-sa/item-load-sa.component';
+import {Logger} from "../../utility/logger";
 
 // TODO: Move stem-related code into separate component (called StemComponent)
 // TODO: Move exemplar response-related code into separate component (called ExemplarResponsesComponent)
@@ -31,11 +32,13 @@ export class ItemLoadComponent implements OnInit, AfterViewInit {
 
     @ViewChild(ItemLoadSaComponent) saItemComponent;
 
-    constructor(private router: Router,
-                private route: ActivatedRoute,
-                private lookupService: LookupService,
-                private itemService: ItemService) {
-    }
+    constructor(
+      private logger: Logger,
+      private router: Router,
+      private route: ActivatedRoute,
+      private lookupService: LookupService,
+      private itemService: ItemService
+    ) { }
 
     ngOnInit() {
         this._loading = true;
@@ -46,7 +49,7 @@ export class ItemLoadComponent implements OnInit, AfterViewInit {
                 this._currentItemId = params['id'];
             });
 
-        console.log('id: ' + this._currentItemId);
+        this.logger.debug('id: ' + this._currentItemId);
 
         if (isNumeric(this._currentItemId)) {
             this.lookupService.getUser()
@@ -54,7 +57,7 @@ export class ItemLoadComponent implements OnInit, AfterViewInit {
                     (res: Response) => {
                         this._user = res.json();
                     },
-                    error => console.log(error),
+                    error => this.logger.error(error),
                     () => {
                         this.itemService.findItem(this._currentItemId)
                             .subscribe(
@@ -75,7 +78,7 @@ export class ItemLoadComponent implements OnInit, AfterViewInit {
     ngAfterViewInit() {}
 
     public createItem(): void {
-      console.log('creating item: ' + JSON.stringify(this.saItemComponent.getUpdatedItem()));
+      this.logger.debug('creating item: ' + JSON.stringify(this.saItemComponent.getUpdatedItem()));
       // TODO: What if this fails?  Need to not redirect to / on failure
       this.itemService.commitItemCreate(this.saItemComponent.getUpdatedItem());
       this.router.navigateByUrl('/');
@@ -104,7 +107,7 @@ export class ItemLoadComponent implements OnInit, AfterViewInit {
     }
 
     public commitItem(): void {
-      console.log('committing item: ' + JSON.stringify(this.saItemComponent.getUpdatedItem()));
+      this.logger.debug('committing item: ' + JSON.stringify(this.saItemComponent.getUpdatedItem()));
       // TODO: What if this fails?  Need to not redirect to / on failure
       this.itemService.commitItemEdit(this.saItemComponent.getUpdatedItem(), 'IAT generated commit');
       this.router.navigateByUrl('/');
@@ -157,7 +160,7 @@ export class ItemLoadComponent implements OnInit, AfterViewInit {
     }
 
     private onSuccess(item): void {
-        console.log('retrieved item: ', JSON.stringify(item));
+        this.logger.debug('retrieved item: ' + JSON.stringify(item));
         let navBarMsgPrefix: string;
         this._currentItem = item;
         this._currentItem.description = this.lookupService.getItemDescription(this._currentItem.type);
@@ -181,8 +184,7 @@ export class ItemLoadComponent implements OnInit, AfterViewInit {
         this._loading = false;
         this._serviceError = true;
 
-        console.log('Error Status: ' + error.status);
-        // console.log('Error Object: ' + error);
+        this.logger.error('Error Status: ' + error.status);
 
         switch (error.status) {
           case 400:

--- a/src/app/item/item-redirect/item-redirect.component.ts
+++ b/src/app/item/item-redirect/item-redirect.component.ts
@@ -1,5 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import { Router, ActivatedRoute } from '@angular/router';
+import {Logger} from "../../utility/logger";
 
 @Component({
   selector: 'app-item-redirect',
@@ -10,6 +11,7 @@ export class ItemRedirectComponent implements OnInit {
   private _itemId: number;
 
   constructor(
+    private logger: Logger,
     private router: Router,
     private route: ActivatedRoute
   ) { }

--- a/src/app/item/item-redirect/item-redirect.component.ts
+++ b/src/app/item/item-redirect/item-redirect.component.ts
@@ -1,6 +1,20 @@
-import { Component, OnInit } from '@angular/core';
-import { Router, ActivatedRoute } from '@angular/router';
-import {Logger} from "../../utility/logger";
+/*
+ * Copyright 2017 Regents of the University of California.
+ *
+ * Licensed under the Educational Community License, Version 2.0 (the "license");
+ * you may not use this file except in compliance with the License. You may
+ * obtain a copy of the license at
+ *
+ * https://opensource.org/licenses/ECL-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {Component, OnInit} from "@angular/core";
+import {ActivatedRoute, Router} from "@angular/router";
 
 @Component({
   selector: 'app-item-redirect',
@@ -8,22 +22,18 @@ import {Logger} from "../../utility/logger";
   styleUrls: ['./item-redirect.component.less']
 })
 export class ItemRedirectComponent implements OnInit {
-  private _itemId: number;
+  private itemId: number;
 
-  constructor(
-    private logger: Logger,
-    private router: Router,
-    private route: ActivatedRoute
-  ) { }
-
-  ngOnInit() {
-
-    this.route.params
-      .subscribe(params => {
-        this._itemId = params['id'];
-      });
-
-    this.router.navigateByUrl('/item/' + this._itemId);
+  constructor(private router: Router,
+              private route: ActivatedRoute) {
   }
 
+  ngOnInit() {
+    this.route.params
+      .subscribe(params => {
+        this.itemId = params['id'];
+      });
+
+    this.router.navigateByUrl('/item/' + this.itemId);
+  }
 }

--- a/src/app/model/exemplar-response.ts
+++ b/src/app/model/exemplar-response.ts
@@ -1,13 +1,27 @@
-/**
- * Created by alexponce on 5/8/17.
+/*
+ * Copyright 2017 Regents of the University of California.
+ *
+ * Licensed under the Educational Community License, Version 2.0 (the "license");
+ * you may not use this file except in compliance with the License. You may
+ * obtain a copy of the license at
+ *
+ * https://opensource.org/licenses/ECL-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 export class ExemplarResponse {
-  public _name: string;
-  public _samplecontent: string;
-  public _purpose: string;
-  public _scorepoint: any;
+  name: string;
 
-  constructor (
-    public id: number
-  ) {}
+  purpose: string;
+
+  samplecontent: string;
+
+  scorepoint: any;
+
+  constructor(public id: number) {
+  }
 }

--- a/src/app/model/item-type.ts
+++ b/src/app/model/item-type.ts
@@ -1,12 +1,26 @@
-/**
- * Created by alexponce on 5/10/17.
+/*
+ * Copyright 2017 Regents of the University of California.
+ *
+ * Licensed under the Educational Community License, Version 2.0 (the "license");
+ * you may not use this file except in compliance with the License. You may
+ * obtain a copy of the license at
+ *
+ * https://opensource.org/licenses/ECL-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 export class ItemType {
-  public type: string;
-  public description: string;
-  public icon: string;
-  public name: string;
-  public abbreviation: string;
+  abbreviation: string;
 
-  constructor () {}
+  icon: string;
+
+  description: string;
+
+  type: string;
+
+  name: string;
 }

--- a/src/app/model/item.ts
+++ b/src/app/model/item.ts
@@ -1,43 +1,78 @@
+/*
+ * Copyright 2017 Regents of the University of California.
+ *
+ * Licensed under the Educational Community License, Version 2.0 (the "license");
+ * you may not use this file except in compliance with the License. You may
+ * obtain a copy of the license at
+ *
+ * https://opensource.org/licenses/ECL-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 // TODO: Convert this item representation to a class hierarchy of item types
 // TODO: Remove all fields not used by front-end from class hierarchy types
 // TODO: Add mappers called at service layer to map between remote JSON and this class hierarchy
 
 export class Item {
-  public id: number;
-  public type: string;
-  public description: string;
-  public version: number;
-  public beingCreatedBy: any;
-  public beingEditedBy: any;
-  public attributes: Attribute[] = [];
-  public contents: Content[] = [];
+  attributes: Attribute[] = [];
+
+  beingCreatedBy: any;
+
+  beingEditedBy: any;
+
+  contents: Content[] = [];
+
+  description: string;
+
+  id: number;
+
+  type: string;
+
+  version: number;
 }
 
 export class Attribute {
-  public attid: string;
-  public name: string;
-  public val: number;
+  attid: string;
+
+  name: string;
+
+  val: number;
 }
 
 export class Content {
-  public language: string;
-  public stem: string;            // TODO: Need to hook into changes to this field to trigger auto-save
-  public rubrics: Rubric[] = [];  // TODO: Need to hook into changes to this field to trigger auto-save
+  language: string;
+
+  rubrics: Rubric[] = [];  // TODO: Need to hook into changes to this field to trigger auto-save
+
+  stem: string;            // TODO: Need to hook into changes to this field to trigger auto-save
 }
 
 export class Rubric {
-  public name: string;            // TODO: Need to hook into changes to this field to trigger auto-save
-  public val: any;
-  public scorepoint: any;
-  public minVal: any;
-  public maxVal: any;
-  public samples: Sample[] = [];
+  maxVal: any;
+
+  minVal: any;
+
+  name: string;            // TODO: Need to hook into changes to this field to trigger auto-save
+
+  val: any;
+
+  samples: Sample[] = [];
+
+  scorepoint: any;
 }
 
 export class Sample {
-  public id: number;
-  public name: string;
-  public samplecontent: string;
-  public purpose: string;
-  public scorepoint: any;
+  id: number;
+
+  name: string;
+
+  purpose: string;
+
+  samplecontent: string;
+
+  scorepoint: any;
 }

--- a/src/app/no-route/no-route.component.ts
+++ b/src/app/no-route/no-route.component.ts
@@ -1,15 +1,24 @@
-import { Component, OnInit } from '@angular/core';
+/*
+ * Copyright 2017 Regents of the University of California.
+ *
+ * Licensed under the Educational Community License, Version 2.0 (the "license");
+ * you may not use this file except in compliance with the License. You may
+ * obtain a copy of the license at
+ *
+ * https://opensource.org/licenses/ECL-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {Component} from "@angular/core";
 
 @Component({
   selector: 'app-no-route',
   templateUrl: './no-route.component.html',
   styleUrls: ['./no-route.component.less']
 })
-export class NoRouteComponent implements OnInit {
-
-  constructor() { }
-
-  ngOnInit() {
-  }
-
+export class NoRouteComponent {
 }

--- a/src/app/service/item.service.spec.ts
+++ b/src/app/service/item.service.spec.ts
@@ -1,6 +1,7 @@
 import { TestBed, inject } from '@angular/core/testing';
 import { HttpModule } from '@angular/http';
 import { ItemService } from './item.service';
+import {Logger} from "../utility/logger";
 
 describe('ItemService', () => {
   beforeEach(() => {
@@ -9,7 +10,8 @@ describe('ItemService', () => {
         HttpModule
       ],
       providers: [
-        ItemService
+        ItemService,
+        Logger
       ]
     });
   });

--- a/src/app/service/lookup.service.ts
+++ b/src/app/service/lookup.service.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@angular/core';
 import { ItemType } from '../model/item-type';
 import { Http } from '@angular/http';
 import { Observable } from 'rxjs/Observable';
+import {Logger} from "../utility/logger";
 
 const MAIN_ITEMS: ItemType[] = [
 /*
@@ -32,6 +33,7 @@ export class LookupService {
   private buildInfoResource = '/manage/info';
 
   constructor(
+    private logger: Logger,
     private http: Http
   ) { }
 
@@ -52,7 +54,6 @@ export class LookupService {
   }
 
   getItemDescription(itemType: string): string {
-
     let selectItem = MAIN_ITEMS.filter(item => item.type === itemType);
 
     if (selectItem != null) {
@@ -66,8 +67,5 @@ export class LookupService {
     }
 
     return '';
-
   }
-
-
 }

--- a/src/app/service/lookup.service.ts
+++ b/src/app/service/lookup.service.ts
@@ -1,41 +1,52 @@
-import { Injectable } from '@angular/core';
-import { ItemType } from '../model/item-type';
-import { Http } from '@angular/http';
-import { Observable } from 'rxjs/Observable';
-import {Logger} from "../utility/logger";
+/*
+ * Copyright 2017 Regents of the University of California.
+ *
+ * Licensed under the Educational Community License, Version 2.0 (the "license");
+ * you may not use this file except in compliance with the License. You may
+ * obtain a copy of the license at
+ *
+ * https://opensource.org/licenses/ECL-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {Injectable} from "@angular/core";
+import {ItemType} from "../model/item-type";
+import {Http} from "@angular/http";
+import {Observable} from "rxjs/Observable";
 
 const MAIN_ITEMS: ItemType[] = [
-/*
-  { id: 10, type: 'ebsr', name: 'Evidence-Based Select Response (EBSR)', icon: 'fa-list'},
-  { id: 11, type: 'eq', name: 'Equation (EQ)', icon: 'fa-superscript'},
-  { id: 13, type: 'gi', name: 'Grid Item (GI)', icon: 'fa-bar-chart'},
-  { id: 14, type: 'ht', name: 'Hot Text (HT)', icon: 'fa-fire'},
-  { id: 15, type: 'mc', name: 'Multiple Choice (MC)', icon: 'fa-list-ul'},
-  { id: 16, type: 'ms', name: 'Multiple Select (MS)', icon: 'fa-th-list'},
-  { id: 17, type: 'mi', name: 'Match Interaction (MI)', icon: 'fa-list-ul'},
-*/
-  { type: 'sa', description: 'Short Answer (SA)', icon: 'fa-font', name: 'Short Answer', abbreviation: 'SA'},
-/*
-  { id: 19, type: 'ti', name: 'Table Interaction (TI)', icon: 'fa-table'},
-  { id: 20, type: 'wer', name: 'Writing Extended Responses (WER)', icon: 'fa-comments'}
-*/
+  /*
+   { id: 10, type: 'ebsr', name: 'Evidence-Based Select Response (EBSR)', icon: 'fa-list'},
+   { id: 11, type: 'eq', name: 'Equation (EQ)', icon: 'fa-superscript'},
+   { id: 13, type: 'gi', name: 'Grid Item (GI)', icon: 'fa-bar-chart'},
+   { id: 14, type: 'ht', name: 'Hot Text (HT)', icon: 'fa-fire'},
+   { id: 15, type: 'mc', name: 'Multiple Choice (MC)', icon: 'fa-list-ul'},
+   { id: 16, type: 'ms', name: 'Multiple Select (MS)', icon: 'fa-th-list'},
+   { id: 17, type: 'mi', name: 'Match Interaction (MI)', icon: 'fa-list-ul'},
+   */
+  {type: 'sa', description: 'Short Answer (SA)', icon: 'fa-font', name: 'Short Answer', abbreviation: 'SA'},
+  /*
+   { id: 19, type: 'ti', name: 'Table Interaction (TI)', icon: 'fa-table'},
+   { id: 20, type: 'wer', name: 'Writing Extended Responses (WER)', icon: 'fa-comments'}
+   */
 ];
 
 const OTHER_ITEMS: ItemType[] = [
   // { type: 'stim', description: 'Stimulus (STIM)', icon: 'fa-commenting-o', name: 'Stimulus', abbreviation: 'STIM'},
-  { type: 'tut', description: 'Tutorial (TUT)', icon: 'fa-question-circle', name: 'Tutorial', abbreviation: 'TUT'}
+  {type: 'tut', description: 'Tutorial (TUT)', icon: 'fa-question-circle', name: 'Tutorial', abbreviation: 'TUT'}
 ];
 
 @Injectable()
 export class LookupService {
-
   private userResource = '/api/users/principal';
   private buildInfoResource = '/manage/info';
 
-  constructor(
-    private logger: Logger,
-    private http: Http
-  ) { }
+  constructor(private http: Http) {
+  }
 
   getUser(): Observable<any> {
     return this.http.request(this.userResource);
@@ -66,6 +77,6 @@ export class LookupService {
       return selectItem[0].description;
     }
 
-    return '';
+    return '';  // TODO: Why is this hardcoded to return empty string?
   }
 }

--- a/src/app/utility/logger.ts
+++ b/src/app/utility/logger.ts
@@ -1,0 +1,25 @@
+import { Injectable } from '@angular/core';
+
+/**
+ * Logger to be used throughout the app instead of directly sending messages to console.
+ */
+@Injectable()
+export class Logger {
+  // TODO: Integrate with JavaScript error tracking solution such as Sentry (https://sentry.io/for/javascript/)
+
+  debug(message: string): void {
+    console.debug(message);
+  }
+
+  info(message: string): void {
+    console.info(message);
+  }
+
+  warn(message: string): void {
+    console.warn(message);
+  }
+
+  error(message: string): void {
+    console.error(message);
+  }
+}

--- a/src/app/utility/logger.ts
+++ b/src/app/utility/logger.ts
@@ -1,4 +1,19 @@
-import { Injectable } from '@angular/core';
+/*
+ * Copyright 2017 Regents of the University of California.
+ *
+ * Licensed under the Educational Community License, Version 2.0 (the "license");
+ * you may not use this file except in compliance with the License. You may
+ * obtain a copy of the license at
+ *
+ * https://opensource.org/licenses/ECL-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {Injectable} from "@angular/core";
 
 /**
  * Logger to be used throughout the app instead of directly sending messages to console.

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -1,15 +1,18 @@
 /*
- * Copyright 2017 Regents of the University of California. Licensed under the Educational Community License, Version
- * 2.0 (the "license"); you may not use this file except in compliance with the License. You may obtain a copy of the
- * license at
+ * Copyright 2017 Regents of the University of California.
+ *
+ * Licensed under the Educational Community License, Version 2.0 (the "license");
+ * you may not use this file except in compliance with the License. You may
+ * obtain a copy of the license at
  *
  * https://opensource.org/licenses/ECL-2.0
  *
- * Unless required under applicable law or agreed to in writing, software distributed under the License is distributed
- * in an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for
- * specific language governing permissions and limitations under the license.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 export const environment = {
   production: true
 };

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -1,20 +1,22 @@
 /*
- * Copyright 2017 Regents of the University of California. Licensed under the Educational Community License, Version
- * 2.0 (the "license"); you may not use this file except in compliance with the License. You may obtain a copy of the
- * license at
+ * Copyright 2017 Regents of the University of California.
+ *
+ * Licensed under the Educational Community License, Version 2.0 (the "license");
+ * you may not use this file except in compliance with the License. You may
+ * obtain a copy of the license at
  *
  * https://opensource.org/licenses/ECL-2.0
  *
- * Unless required under applicable law or agreed to in writing, software distributed under the License is distributed
- * in an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for
- * specific language governing permissions and limitations under the license.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 // The file contents for the current environment will overwrite these during build.
 // The build system defaults to the dev environment which uses `environment.ts`, but if you do
 // `ng build --env=prod` then `environment.prod.ts` will be used instead.
 // The list of which env maps to which file can be found in `angular-cli.json`.
-
 export const environment = {
   production: false
 };

--- a/tslint.json
+++ b/tslint.json
@@ -6,7 +6,7 @@
     "callable-types": true,
     "class-name": true,
     "comment-format": [
-      true,
+      false,
       "check-space"
     ],
     "curly": true,
@@ -24,21 +24,18 @@
     "interface-over-type-literal": true,
     "label-position": true,
     "max-line-length": [
-      true,
+      false,
       180
     ],
     "member-access": false,
     "member-ordering": [
       true,
-      "static-before-instance",
       "variables-before-functions"
     ],
     "no-arg": true,
     "no-bitwise": true,
     "no-console": [
       true,
-      "debug",
-      "info",
       "time",
       "timeEnd",
       "trace"
@@ -71,7 +68,7 @@
     ],
     "prefer-const": true,
     "quotemark": [
-      true,
+      false,
       "single"
     ],
     "radix": true,


### PR DESCRIPTION
I made some changes to the TS files that you should pull in before you move forward with more work on the front-end code (to avoid conflicts).

**Added Logger**
Refactored console.log calls into Logger defined at app root (globally available).  This Logger is now injected into the components & services.  We should use this instead of direct calls to console.log, console.error, etc.  Later we can plug in a logging framework such as Sentry behind this Logger which will automatically capture all logging to the new framework.

Note, I also changed all of the old console.log calls to be Logger.debug calls (which ends up calling console.info) since I don't think we want the console containing our debugging statements for the end users  (unless they turn on info level logging).

**General Cleanup**
I did some cleanup to help with consistency and working within the files.
Cleaned up all non-spec .ts files:

- Removed prefix underscores for private variables.  See https://github.com/Microsoft/TypeScript/wiki/Coding-guidelines.  Note that this doesn't appear to be a universal standard, but here's why I think we should not use prefix underscores:
-- The leading underscore is harder to type, and harder to read
-- The only time we need the leading underscore is to differentiate a backing field from the corresponding property get / set function names.  I'd say if we're creating a backing field for a get and/or set method then we should use the _ prefix.  Otherwise let's not name our private fields with this convention.  To see how ugly it would be if we used this convention for all private fields, consider how it would look if all injected private constructor parameters were named with a leading underscore (e.g. _logger, _lookupService).
- Moved get / set methods to immediately follow their backing field (no blank line).  This makes it clear why a private field is named with a leading underscore since it is immediately followed by its getter and/or setter (see item-load.component.ts for a good example)
- Re-ordered contents of all classes as follows (makes it easier to find things):  Fields (and get/set methods), constructor (which can add to fields), public methods, private methods
- Alphabetized field lists in model types (helpful with these dumb data transfer types some of which have lots of fields)
- Added return types to all functions
- Formatted code & optimized imports using default IntelliJ settings.  We should be doing this before committing any code.  The menu options in IntelliJ are:
Code -> Reformat Code
Code -> Optimize Imports
- Removed extra blank lines
- Removed blank lines between decorators and the thing they decorate (e.g. classes)
- Removed use of "public" everywhere (it's the default) except in constructor parameter lists where public is shorthand for defining public fields fields
- Removed empty constructors
- Removed implementation of interfaces where implemented method was empty
- Added copyright header