### PR TITLE
Feature/iat 420

### DIFF
--- a/src/app/service/item.service.ts
+++ b/src/app/service/item.service.ts
@@ -47,8 +47,8 @@ export class ItemService {
 
     return this.http
       .get(ItemService.serviceUrl + '/' + itemId, ItemService.requestOptions)
-      .map(ItemService.extractJson)
-      .catch(this.handleError);
+      .map(res => ItemService.extractJson(res))
+      .catch(err => this.handleError(err));
   }
 
   //---------------------------------------------------------------------------
@@ -62,8 +62,8 @@ export class ItemService {
 
     return this.http
       .post(url, { 'type': itemType }, ItemService.requestOptions)
-      .map(ItemService.extractJson)
-      .catch(this.handleError);
+      .map(res => ItemService.extractJson(res))
+      .catch(err => this.handleError(err));
   }
 
   // Commit the creation of the item (the item will become available in the system)
@@ -122,7 +122,7 @@ export class ItemService {
     return this.http
       .put(url, null, ItemService.requestOptions)
       .map(() => { return new Observable<boolean>(); })
-      .catch(this.handleError);
+      .catch(err => this.handleError(err));
   }
 
   // Commit the editing of the item (the changes to the item will become available in the system)
@@ -195,6 +195,9 @@ export class ItemService {
 
   // TODO: Can this be removed once all public methods return Observables instead of handling errors internally?
   private handleError(error: Response | any): any {
+
+    this.logger.error(JSON.stringify(error));
+
     let message: string;
     if (error instanceof Response) {
       const body = error.json() || '';

--- a/src/app/service/item.service.ts
+++ b/src/app/service/item.service.ts
@@ -195,9 +195,6 @@ export class ItemService {
 
   // TODO: Can this be removed once all public methods return Observables instead of handling errors internally?
   private handleError(error: Response | any): any {
-
-    this.logger.error(JSON.stringify(error));
-
     let message: string;
     if (error instanceof Response) {
       const body = error.json() || '';


### PR DESCRIPTION
Changed the values that .map and .catch methods receive to lambda functions. This allowed the proper handing of error responses returned by IMS.
The easiest way to test this fix is to attempt to retrieve a non-existent item id such as this:
http://localhost:4200/item/1411660000