### PR TITLE
IAT-444:  Added two gradle tasks:  ngPrune and ngInstall.  All fronte…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -98,6 +98,10 @@ task ngInstall(type: Exec) {
     commandLine 'npm', 'install'
 }
 
+task ngPrune(type: Exec) {
+    commandLine 'npm', 'install'
+}
+
 task ngBuild(type: Exec) {
     if (project.hasProperty('production')) {
         commandLine 'npm', 'run', 'ng-build-prod'
@@ -105,6 +109,8 @@ task ngBuild(type: Exec) {
         commandLine 'npm', 'run', 'ng-build'
     }
 }
+
+ngBuild.dependsOn ngInstall, ngPrune
 
 /***************************
  * build information


### PR DESCRIPTION
Added two gradle tasks: ngPrune and ngInstall. 

All frontend commands like ‘npm’ or ‘ng’ created as gradle tasks are prefixed with ‘ng’ so ngBuild, ngPrune, ngInstall.  I went with this convention trying to keep it simple.