### PR TITLE
Feature/iat 477

### DIFF
--- a/src/app/item/components/find-item/find-item.component.html
+++ b/src/app/item/components/find-item/find-item.component.html
@@ -1,14 +1,15 @@
 <form [formGroup]="complexForm" (ngSubmit)="submitForm(complexForm.value)">
   <div class="col-md-8">
-  <div class="input-group" [ngClass]="{'has-error':!complexForm.controls['query'].valid}">
-     <input type="text" class="form-control" placeholder="Item or stimulus ID"
-           [formControl]="complexForm.controls['query']" maxlength="16"/>
-     <span class="input-group-btn">
+    <div class="input-group" [ngClass]="{'has-error':!complexForm.controls['query'].valid}">
+      <input type="text" class="form-control" placeholder="Item or stimulus ID"
+             [formControl]="complexForm.controls['query']" maxlength="16"
+             (keypress)="_keyPress($event)"/>
+      <span class="input-group-btn">
        <button class="btn btn-primary" type="submit" [disabled]="!complexForm.valid">
          <i class="fa fa-search" aria-hidden="true"></i>
          Search
        </button>
      </span>
+    </div>
   </div>
-</div>
 </form>

--- a/src/app/item/components/find-item/find-item.component.ts
+++ b/src/app/item/components/find-item/find-item.component.ts
@@ -23,4 +23,13 @@ export class FindItemComponent {
     this.router.navigateByUrl('/item/' + value.query);
   }
 
+  _keyPress(event: any) {
+    const pattern = /^[@#%&()=\\;.?/]+$/;
+    let inputChar = String.fromCharCode(event.charCode);
+
+    if (pattern.test(inputChar)) {
+      // invalid character, prevent input
+      event.preventDefault();
+    }
+  }
 }

--- a/src/app/item/components/find-item/find-item.component.ts
+++ b/src/app/item/components/find-item/find-item.component.ts
@@ -25,7 +25,7 @@ export class FindItemComponent {
 
   _keyPress(event: any) {
     const pattern = /^[@#%&()=\\;.?/]+$/;
-    let inputChar = String.fromCharCode(event.charCode);
+    const inputChar = String.fromCharCode(event.charCode);
 
     if (pattern.test(inputChar)) {
       // invalid character, prevent input


### PR DESCRIPTION
Added the first pass at restricting special characters from the item search.  Users are no longer able to type in these characters @#%&()=\;.?/

Those characters cause the front end to fail with a URI malformed error.

This is the first pass because a user can still copy and paste the special characters into the input and submit the form resulting in an error.