### PR TITLE
IAT-486:  Removed the hardcoding and used the @Value to set the ‘imsA…

### DIFF
--- a/src/main/java/org/opentestsystem/ap/iat/controller/ItemDiffController.java
+++ b/src/main/java/org/opentestsystem/ap/iat/controller/ItemDiffController.java
@@ -5,6 +5,7 @@ import java.util.List;
 import lombok.Data;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.ResponseEntity;
@@ -20,6 +21,9 @@ public class ItemDiffController {
 
     private final RestTemplate restTemplate;
 
+    @Value("${zuul.routes.ims-api.url}")
+    private String imsApi;
+
     @Autowired
     public ItemDiffController(final RestTemplate restTemplate) {
         this.restTemplate = restTemplate;
@@ -30,7 +34,7 @@ public class ItemDiffController {
         log.debug("Getting diff for item {} and history ID {}", itemId, historyId);
 
         final ResponseEntity<List<ItemDiff>> response = restTemplate.exchange
-            ("http://localhost:8081/api/v1/items/{itemId}/diff/{historyId}",
+            (imsApi + "/v1/items/{itemId}/diff/{historyId}",
                 HttpMethod.GET,
                 null,
                 new ParameterizedTypeReference<List<ItemDiff>>() {


### PR DESCRIPTION
I was working on the item diff a lot over the weekend and trying many different things so that is my excuse :)  Regardless I can't believe I let this slip through.

I caught this when deploying to AWS.  I checked the diff and it complained it couldn't find IMS on localhost:8081.  Doh!

I should mention I updated the AWS environments already.  I wanted to confirm it worked.  And it does so the diff will work for the demo.