### PR TITLE
Changed approach to set the has-error class on search input

### DIFF
--- a/src/app/item/components/item-dashboard/find-item/find-item.component.html
+++ b/src/app/item/components/item-dashboard/find-item/find-item.component.html
@@ -1,6 +1,6 @@
 <form [formGroup]="complexForm" (ngSubmit)="submitForm(complexForm.value)">
   <div class="col-md-8">
-    <div class="input-group" [ngClass]="{'has-error':!complexForm.controls['query'].valid}">
+    <div class="input-group" [class.has-error]="complexForm.controls['query'].invalid">
       <input type="text"
              class="form-control"
              placeholder="Item or stimulus ID"

--- a/src/app/item/components/item-dashboard/find-item/find-item.component.html
+++ b/src/app/item/components/item-dashboard/find-item/find-item.component.html
@@ -1,6 +1,6 @@
 <form [formGroup]="complexForm" (ngSubmit)="submitForm(complexForm.value)">
   <div class="col-md-8">
-    <div class="input-group" [class.has-error]="complexForm.controls['query'].invalid">
+    <div class="input-group" [class.has-error]="complexForm.invalid">
       <input type="text"
              class="form-control"
              placeholder="Item or stimulus ID"


### PR DESCRIPTION
Using the [ngClass] with embedded logic proved to be the root cause of the ExpressionChangedAfterItHasBeenCheckedError exception.

The new approach uses [class.has-error] to set the class whenever any input in the form is invalid