### PR TITLE
Feature/iat 523

### DIFF
--- a/src/app/app.routing.ts
+++ b/src/app/app.routing.ts
@@ -8,6 +8,7 @@ import {AppResourceNotFoundComponent} from "./app-resource-not-found.component/a
 const routes: Routes = [
   {path: '', component: ItemDashboardComponent},
   {path: 'item/:id', component: ItemCrudComponent},
+  {path: 'item/:id/:tab', component: ItemCrudComponent},
   {path: 'item/create/select-type', component: ItemCreateComponent},
   {path: 'unavailable', component: AppResourceNotFoundComponent},
   {path: '**', component: AppResourceNotFoundComponent}

--- a/src/app/item/crud/item-crud.component.html
+++ b/src/app/item/crud/item-crud.component.html
@@ -87,7 +87,7 @@
         <!-- Item tabs -->
         <item-tabs [item]="item"
                    [itemType]="item.itemType"
-                   [selected]="'history'"
+                   [selected]="selectedTab"
                    [isReadOnly]="isBeingViewedByCurrentUser"
                    (itemChanged)="autoSave.onItemChange($event)">
         </item-tabs>

--- a/src/app/item/crud/item-crud.component.ts
+++ b/src/app/item/crud/item-crud.component.ts
@@ -25,6 +25,7 @@ export class ItemCrudComponent implements OnInit {
   isLoading: boolean;
   isError = false;
   errorMessage: string;
+  selectedTab: string;
   @ViewChild(ItemDetailsComponent) itemDetailsComponent;
 
   get mode(): string {
@@ -127,7 +128,7 @@ export class ItemCrudComponent implements OnInit {
       .subscribe(
         params => {
           const itemId = params['id'];
-
+          this.selectedTab = params['tab'];
           // Load current user
           this.userService.findCurrentUser()
             .subscribe(

--- a/src/app/item/crud/tabs/item-tabs.component.ts
+++ b/src/app/item/crud/tabs/item-tabs.component.ts
@@ -43,7 +43,7 @@ export class ItemTabsComponent {
     // Reload tab content
     this.selected = tab;
     // Update URL to reflect new tab. This does NOT cause the entire page to reload
-    this.location.go("/item/" + this.item.id + "/" + tab)
+    this.location.go("/item/" + this.item.id + "/" + tab);
   }
 
   onItemChanged(): void {

--- a/src/app/item/crud/tabs/item-tabs.component.ts
+++ b/src/app/item/crud/tabs/item-tabs.component.ts
@@ -1,9 +1,9 @@
 import {Component, EventEmitter, Input, Output, ViewChild} from "@angular/core";
+import {Location} from "@angular/common";
 import {Item} from "../../services/item.service/item";
 import {ItemType} from "../../services/item-type.service/item-type";
 import {NormalItem} from "../../services/item.service/normal-item";
 import {ItemStimulusTabComponent} from "./item-stimulus-tab.component/item-stimulus-tab.component";
-import {ItemWorkflowService} from "../../services/item-workflow.service/item-workflow.service";
 import {ItemWorkflowTabComponent} from "./item-workflow-tab.component/item-workflow-tab.component";
 
 @Component({
@@ -12,6 +12,7 @@ import {ItemWorkflowTabComponent} from "./item-workflow-tab.component/item-workf
   styleUrls: ['./item-tabs.component.less']
 })
 export class ItemTabsComponent {
+  validTabs = ['history', 'stimulus', 'workflow'];
   @Input() item: Item;
   @Input() itemType: ItemType;
   @Input() selected: string;
@@ -24,12 +25,25 @@ export class ItemTabsComponent {
     return (this.item as NormalItem).stimulusId;
   }
 
+  constructor(private location: Location) {
+  }
+
   isSelected(tab: string): boolean {
-    return this.selected === tab;
+    let validSelected = this.selected;
+    // Check if selected tab name is supported
+    if (this.validTabs.indexOf(this.selected) < 0) {
+      // Default to first valid tab name
+      validSelected = this.validTabs[0];
+    }
+
+    return validSelected === tab;
   }
 
   select(tab: string): void {
+    // Reload tab content
     this.selected = tab;
+    // Update URL to reflect new tab. This does NOT cause the entire page to reload
+    this.location.go("/item/" + this.item.id + "/" + tab)
   }
 
   onItemChanged(): void {


### PR DESCRIPTION
* Added new item route path that includes the tab name
* Passed selectedTab value to item-tabs component input parameter
* Added tab names validation to prevent errors if the tab name is incorrect. Defaults to 'history' tab, same as previous functionality
* Used angular Location service to change the browser URL without reloading the page
```this.location.go("/item/" + this.item.id + "/" + tab);```