### PR TITLE
Finalize Feature/iat 523

### DIFF
--- a/src/app/app.routing.ts
+++ b/src/app/app.routing.ts
@@ -6,7 +6,10 @@ import {ItemCrudComponent} from "./item/crud/item-crud.component";
 import {AppResourceNotFoundComponent} from "./app-resource-not-found.component/app-resource-not-found.component";
 
 const routes: Routes = [
-  {path: '', component: ItemDashboardComponent},
+  {
+    path: '',
+    component: ItemDashboardComponent
+  },
   {
     path: 'item',
     children: [
@@ -27,8 +30,14 @@ const routes: Routes = [
       },
     ]
   },
-  {path: 'unavailable', component: AppResourceNotFoundComponent},
-  {path: '**', component: AppResourceNotFoundComponent}
+  {
+    path: 'unavailable',
+    component: AppResourceNotFoundComponent
+  },
+  {
+    path: '**',
+    component: AppResourceNotFoundComponent
+  }
 ];
 
 @NgModule({

--- a/src/app/item/crud/item-crud.component.html
+++ b/src/app/item/crud/item-crud.component.html
@@ -89,6 +89,7 @@
                    [itemType]="item.itemType"
                    [selected]="selectedTab"
                    [isReadOnly]="isBeingViewedByCurrentUser"
+                   (tabChanged)="onTabChanged($event)"
                    (itemChanged)="autoSave.onItemChange($event)">
         </item-tabs>
       </div>

--- a/src/app/item/crud/tabs/item-tabs.component.ts
+++ b/src/app/item/crud/tabs/item-tabs.component.ts
@@ -17,6 +17,7 @@ export class ItemTabsComponent {
   @Input() itemType: ItemType;
   @Input() selected: string;
   @Input() isReadOnly: boolean;
+  @Output() tabChanged = new EventEmitter<String>();
   @Output() itemChanged = new EventEmitter<Item>();
   @ViewChild(ItemStimulusTabComponent) itemStimulusTabComponent;
   @ViewChild(ItemWorkflowTabComponent) itemWorkflowTabComponent;
@@ -44,6 +45,7 @@ export class ItemTabsComponent {
     this.selected = tab;
     // Update URL to reflect new tab. This does NOT cause the entire page to reload
     this.location.go("/item/" + this.item.id + "/" + tab);
+    this.tabChanged.emit(this.selected);
   }
 
   onItemChanged(): void {


### PR DESCRIPTION
**Include the selected item tab in URL**
* Formatted routing configuration
* Added tabEvent event emitter to notify crud component of the current selected tab
* Changed loadItem() signature to allow selected tab to be passed in

1. This feature now allows links to items and the tab to display by using any of these three URL variations:
```
/item/MC34/history
/item/MC34/stimulus
/item/MC34/workflow
```
If no tab identifier is passed 'history' is used as default

2. When editing an item, the tab that was selected prior to clicking the Edit button will now be displayed