### PR TITLE
Fixed uploadedDate datetime defect; 

### DIFF
--- a/src/app/item/crud/tabs/item-braille-tab.component/item-braille-tab.component.ts
+++ b/src/app/item/crud/tabs/item-braille-tab.component/item-braille-tab.component.ts
@@ -63,7 +63,8 @@ export class ItemBrailleTabComponent implements OnInit, OnChanges {
     // Overwrite uploader functions
     this.uploader.onSuccessItem = (item: FileItem, response: string, status: number, headers: ParsedResponseHeaders) => {
       this.logger.info('Successfully uploaded: ' + item.file.name);
-      const responseDate = Date.now().toString();
+
+      const responseDate = this.getCurrentUTCDate();
 
       // Check if file was overwritten
       const existingFile = this.brailleAttachments.filter(file => file.fileName === item.file.name);
@@ -153,5 +154,10 @@ export class ItemBrailleTabComponent implements OnInit, OnChanges {
       );
     this.deleteFileName = "";
     this.deleteModal.hide();
+  }
+
+  private getCurrentUTCDate(): string {
+    const utcString = new Date(Date.now()).toUTCString();
+    return new Date(utcString).toISOString();
   }
 }


### PR DESCRIPTION
This issue was caused by an incorrectly formatted uploadedDate being placed on the front-end braille attachment model. When autosave or commit was called IMS would fail validation of the provided model. The Braille attachments are ignored when autosaving and committing because files are automatically pushed upon successful upload. One option was to avoid sending them in the front-end model altogether. This option would have taken more time to implement and possibly caused maintenance confusion in the future. Providing a properly ISO Date string fixed the issue.